### PR TITLE
Handle errors gracefully on --get-all

### DIFF
--- a/kobodl/actions.py
+++ b/kobodl/actions.py
@@ -212,8 +212,11 @@ def GetBookOrBooks(user: User, outputPath: str, productId: str = '') -> Union[No
             click.echo(f'Skipping archived book {fileName}')
             continue
 
-        kobo.Download(bookMetadata, book_type == BookType.AUDIOBOOK, outputFilePath)
-        click.echo(f'Downloaded {productId} to {outputFilePath}', err=True)
+        try:
+            kobo.Download(bookMetadata, book_type == BookType.AUDIOBOOK, outputFilePath)
+            click.echo(f'Downloaded {productId} to {outputFilePath}', err=True)
+        except KoboException as e:
+            click.echo(str(e), err=True)
 
         if productId:
             # TODO: support audiobook downloads from web


### PR DESCRIPTION
Just a simple try/except on get-all that allows the process to continue past the book that gives the error. Doing this because as soon as you preorder something, the preordered book gives an error that bubbles to the top and stops the whole execution.