### PR TITLE
Add --captcha login option for when pyperclip doesnt work

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It doesn't work with audiobooks and is a little harder to set up, but I think it
 
 This is a hard fork of [kobo-book-downloader](https://github.com/TnS-hun/kobo-book-downloader), a command line tool to download and remove Digital Rights Management (DRM) protection from media legally purchased from [Rakuten Kobo](https://www.kobo.com/). The resulting [EPUB](https://en.wikipedia.org/wiki/EPUB) files can be read with, amongst others, [KOReader](https://github.com/koreader/koreader).
 
-> **NOTE:** You must have a kobo email login for this tool to work (you can't use an external provider like Google or Facebook). However, you can create a NEW kobo account and link it with your existing account on the user profile page. Go to `My Account -> Account Settings` to link your new kobo login.
+> **NOTE:** You must have a kobo email login.  See "I can't log in" in the troubleshooting section for how to workaround this requirement.
 
 ## Features
 
@@ -228,6 +228,18 @@ You must add your CalibreWeb server and user details directly in kobodl.json.  M
 
 ## Troubleshooting
 
+> I can't log in.  My credentials are rejected.
+
+You must have a kobo email login for this tool to work (you can't use an external provider like Google or Facebook). However, you can create a NEW kobo account and link it with your existing account on the user profile page. Go to `My Account -> Account Settings` to link your new kobo login.
+
+> I can't log in.  I get a message saying "The page format might have changed"
+
+This happens from time to time, maybe once or twice a year.  Kobo changes their login page and makes it hard for the tool to parse out the necessary information.  Please open an issue.
+
+> I can't log in, there's a problem with reading the captcha
+
+The clipboard interaction doesn't work for everyone.  Try supplying the captcha using `koobdl user add --captch "YOUR_CAPTCHA_CODE"`.
+
 > Some of my books are missing!
 
 Try `kobodl book list --read` to show all "finished" and "archived" books.  You can manage your book status on [the library page](https://kobo.com/library).  Try changing the status using the "..." button.
@@ -235,10 +247,6 @@ Try `kobodl book list --read` to show all "finished" and "archived" books.  You 
 > I see a mesage about "skipping _____" when I download all.
 
 Try to download the book individually using `kobodl book get <revision-id>`, replacing `revision-id` with the UUID from the list table.
-
-> I can't log in.  I get a message saying "The page format might have changed"
-
-This happens from time to time, maybe once or twice a year.  Kobo changes their login page and makes it hard for the tool to parse out the necessary information.  Please open an issue.
 
 > Something else is going wrong!
 

--- a/kobodl/commands/user.py
+++ b/kobodl/commands/user.py
@@ -45,9 +45,10 @@ def list(ctx, identifier):
 
 @user.command(name='add', help='add new user')
 @click.option('--email', prompt=True, hide_input=False, type=click.STRING, help="kobo.com email.")
+@click.option('--captcha', type=click.STRING, help="kobo.com captcha.")
 @click.password_option(help="kobo.com password (not stored)")
 @click.pass_obj
-def add(ctx, email, password):
+def add(ctx, email, captcha, password):
     user = User(Email=email)
     click.echo(
         """
@@ -72,9 +73,10 @@ def add(ctx, email, password):
     and paste it here.  It will be very long!
     """
     )
-    input('Press enter after copying the captcha code...')
-    captcha = pyperclip.paste().strip()
-    click.echo(f'Read captcha code from clipboard: {captcha}')
+    if not captcha:
+        input('Press enter after copying the captcha code...')
+        captcha = pyperclip.paste().strip()
+        click.echo(f'Read captcha code from clipboard: {captcha}')
     actions.Login(user, password, captcha)
     Globals.Settings.UserList.users.append(user)
     Globals.Settings.Save()


### PR DESCRIPTION
If there's a problem with pyperclip, you can just provide it as an argument with `kobodl user add --captcha "code_here"`.

fixes #97 