### PR TITLE
Fix epub specification violation

### DIFF
--- a/kobodl/koboDrmRemover.py
+++ b/kobodl/koboDrmRemover.py
@@ -36,4 +36,7 @@ class KoboDrmRemover:
                     contentKeyBase64 = contentKeys.get(filename, None)
                     if contentKeyBase64 is not None:
                         contents = self.__DecryptContents(contents, contentKeyBase64)
-                    outputZip.writestr(filename, contents)
+                    if filename == "mimetype":
+                        outputZip.writestr(filename, contents, compress_type=zipfile.ZIP_STORED)
+                    else:
+                        outputZip.writestr(filename, contents)


### PR DESCRIPTION
According to the epub
specifications (https://www.w3.org/TR/epub/#sec-zip-container-mime) epub creators must not compress the mimetype file in the epub. The updated RemoveDrm function creates a new zip file with using the `ZIP_DEFLATED` compression method for all the files, except mimetype