### PR TITLE
Fix 403 authorization errors

### DIFF
--- a/kobodl/kobo.py
+++ b/kobodl/kobo.py
@@ -133,7 +133,7 @@ class Kobo:
 
         return {"response": ReauthenticationHook}
 
-    def __GetExtraLoginParameters(self) -> Tuple[str, str, str]:
+    def __GetExtraLoginParameters(self) -> Tuple[str, str, str, str]:
         signInUrl = self.InitializationSettings["sign_in_page"]
 
         params = {
@@ -528,11 +528,6 @@ class Kobo:
 
         cookie = SimpleCookie()
         cookie.load(authCookie)
-
-        def get_cookie_value(cookie_name):
-            if cookie_name in cookie:
-                return cookie[cookie_name].value
-            return None
 
         url = match.group(1)
         parsed = urllib.parse.urlparse(url)

--- a/kobodl/kobo.py
+++ b/kobodl/kobo.py
@@ -8,7 +8,6 @@ import time
 import gzip
 import urllib
 import json
-import io
 import copy
 import http.cookiejar
 from http.cookies import SimpleCookie

--- a/kobodl/kobo.py
+++ b/kobodl/kobo.py
@@ -581,14 +581,6 @@ class Kobo:
                     "Please be sure to remove any personally identifying information from the file."
                 )
 
-        url = match.group(1)
-        parsed = urllib.parse.urlparse(url)
-        parsedQueries = urllib.parse.parse_qs(parsed.query)
-        self.user.UserId = parsedQueries["userId"][
-            0
-        ]  # We don't call self.Settings.Save here, AuthenticateDevice will do that if it succeeds.
-        userKey = parsedQueries["userKey"][0]
-
         cookie = SimpleCookie()
         cookie.load(authCookie)
 

--- a/kobodl/kobo.py
+++ b/kobodl/kobo.py
@@ -357,10 +357,13 @@ class Kobo:
 
         for item in data['Spine']:
             fileNum = int(item['Id']) + 1
-            response = self.Session.get(item['Url'], stream=True)
             filePath = os.path.join(outputPath, str(fileNum) + '.' + item['FileExtension'])
+            request = Request(item['Url'], headers=self.Session.headers)
+            response = request.make_request()
+            byte_string = response['content']
             with open(filePath, "wb") as f:
-                for chunk in response.iter_content(chunk_size=1024 * 256):
+                for i in range(0, len(byte_string), 1024 * 256):
+                    chunk = byte_string[i:i + 1024 * 256]
                     f.write(chunk)
 
     # PUBLIC METHODS:

--- a/kobodl/kobo.py
+++ b/kobodl/kobo.py
@@ -52,7 +52,7 @@ class Kobo:
     ApplicationVersion = "10.1.4.39810"
     DefaultPlatformId = "00000000-0000-0000-0000-000000004000"
     DisplayProfile = "Android"
-    UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Google Nexus 7 2013 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Safari/537.36 KoboApp/10.1.4.39810 KoboPlatform Id/00000000-0000-0000-0000-000000004000 KoboAffiliate/KoboApp KoboBuildFlavor/global"
+    UserAgent = "Mozilla/5.0 (Linux; Android 6.0; Google Nexus 7 2013 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Safari/537.36 KoboApp/8.40.2.29861 KoboPlatform Id/00000000-0000-0000-0000-000000004000 KoboAffiliate/Kobo KoboBuildFlavor/global"
 
     def __init__(self, user: User):
         self.InitializationSettings = {}
@@ -161,7 +161,7 @@ class Kobo:
         response = opener.open(request)
         htmlResponse = str(response.read())
 
-        cookie_string = '; '.join([f'{cookie.name}={cookie.value}' for cookie in cookie_jar])
+        authCookie = '; '.join([f'{cookie.name}={cookie.value}' for cookie in cookie_jar])
 
         # The link can be found in the response ('<a class="kobo-link partner-option kobo"') but this will do for now.
         parsed = urllib.parse.urlparse(signInUrl)
@@ -184,7 +184,7 @@ class Kobo:
             )
         requestVerificationToken = html.unescape(match.group(1))
 
-        return koboSignInUrl, workflowId, requestVerificationToken, cookie_string
+        return koboSignInUrl, workflowId, requestVerificationToken, authCookie
 
     def __GetMyBookListPage(self, syncToken: str) -> Tuple[list, str]:
         url = self.InitializationSettings["library_sync"]
@@ -469,7 +469,7 @@ class Kobo:
             signInUrl,
             workflowId,
             requestVerificationToken,
-            cookie_string
+            authCookie
         ) = self.__GetExtraLoginParameters()
 
         postData = {
@@ -492,7 +492,7 @@ class Kobo:
             'Priority': 'u=4', 'TE': 'trailers',
             'Pragma': 'no-cache', 'Cache-Control':
             'no-cache',
-            'Cookie': cookie_string
+            'Cookie': authCookie
         }
 
         postData = urllib.parse.urlencode(postData).encode()
@@ -527,7 +527,7 @@ class Kobo:
         userKey = parsedQueries["userKey"][0]
 
         cookie = SimpleCookie()
-        cookie.load(cookie_string)
+        cookie.load(authCookie)
 
         def get_cookie_value(cookie_name):
             if cookie_name in cookie:

--- a/kobodl/kobo.py
+++ b/kobodl/kobo.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 import time
-import gzip
 import urllib
 import json
 import copy
@@ -207,8 +206,7 @@ class Kobo:
         request = Request(url=signInUrl, headers=headers)
         response = request.make_request()
 
-        decoded_response = gzip.decompress(response['content']).decode("utf-8")
-        htmlResponse = str(decoded_response)
+        htmlResponse = str(response['content'])
 
         authCookie = '; '.join([f'{cookie.name}={cookie.value}' for cookie in response['request'].cookie_jar])
 
@@ -560,8 +558,7 @@ class Kobo:
         request = Request(signInUrl, data=postData, headers=headers)
         response = request.make_request()
 
-        decoded_response = gzip.decompress(response['content']).decode('utf-8')
-        htmlResponse = decoded_response
+        htmlResponse = str(response['content'])
 
         match = re.search(r"'(kobo://UserAuthenticated\?[^']+)';", htmlResponse)
         if match is None:


### PR DESCRIPTION
Probably related: #127 

For some reason the authentication process returns 403 errors all of a sudden. I think this is due to CloudFlare blocking the requests automatically. This branch solves it by using `urllib` instead of `requests` in the specific faulty requests, as pointed out in a StackOverflow post](https://stackoverflow.com/a/74674276).