### PR TITLE
Change build action for multi arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
         name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
@@ -19,7 +25,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push server
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           tags: ghcr.io/subdavis/kobodl:latest
           push: true


### PR DESCRIPTION
This PR mainly aims to add support for Docker on arm64.  
Following the [README for build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#usage), it seems the change is pretty straightforward by just adding two steps.

Closes https://github.com/subdavis/kobo-book-downloader/issues/119