### PR TITLE
Switch to using web-based activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,25 +199,11 @@ kobodl --version
 kobodl --debug [OPTIONS] COMMAND [ARGS]...
 ```
 
-## Getting a reCAPTCHA code
-
-Adding a user requires a bit of hackery to get a reCAPTCHA code from Kobo's website. This GIF helps to explain how to do that.
-
-![Gif explaining how to get reCAPTHCA](docs/captcha.gif)
-
 ## Troubleshooting
-
-> I can't log in.  My credentials are rejected.
-
-You must have a kobo email login for this tool to work (you can't use an external provider like Google or Facebook). However, you can create a NEW kobo account and link it with your existing account on the user profile page. Go to `My Account -> Account Settings` to link your new kobo login.
 
 > I can't log in.  I get a message saying "The page format might have changed"
 
 This happens from time to time, maybe once or twice a year.  Kobo changes their login page and makes it hard for the tool to parse out the necessary information.  Please open an issue.
-
-> I can't log in, there's a problem with reading the captcha
-
-The clipboard interaction doesn't work for everyone.  Try supplying the captcha using `koobdl user add --captch "YOUR_CAPTCHA_CODE"`.
 
 > Some of my books are missing!
 
@@ -256,7 +242,7 @@ poetry run tox -e type
 
 ## Notes
 
-kobo-book-downloader will prompt for your [Kobo](https://www.kobo.com/) e-mail address and password. Once it has successfully logged in, it won't ask for them again. Your password will not be stored on disk; Kobodl uses access tokens after the initial login.
+kobo-book-downloader uses the same web-based activation method to login as the Kobo e-readers. You will have to open an activation link—that uses the official [Kobo](https://www.kobo.com/) site—in your browser and enter the code. You might need to login if kobo.com asks you to. Once kobo-book-downloader has successfully logged in, it won't ask for the activation again. kobo-book-downloader doesn't store your Kobo password in any form; it works with access tokens.
 
 Credit recursively to [kobo-book-downloader](https://github.com/TnS-hun/kobo-book-downloader) and the projects that lead to it.
 

--- a/kobodl/actions.py
+++ b/kobodl/actions.py
@@ -161,12 +161,12 @@ def ListBooks(users: List[User], listAll: bool, exportFile: Union[TextIO, None])
             )
 
 
-def Login(user: User, password: str, captcha: str) -> None:
+def Login(user: User) -> None:
     '''perform device initialization and get token'''
     kobo = Kobo(user)
     kobo.AuthenticateDevice()
     kobo.LoadInitializationSettings()
-    kobo.Login(user.Email, password, captcha)
+    kobo.Login()
 
 
 def GetBookOrBooks(

--- a/kobodl/commands/user.py
+++ b/kobodl/commands/user.py
@@ -44,40 +44,10 @@ def list(ctx, identifier):
 
 
 @user.command(name='add', help='add new user')
-@click.option('--email', prompt=True, hide_input=False, type=click.STRING, help="kobo.com email.")
-@click.option('--captcha', type=click.STRING, help="kobo.com captcha.")
-@click.password_option(help="kobo.com password (not stored)")
 @click.pass_obj
-def add(ctx, email, captcha, password):
-    user = User(Email=email)
-    click.echo(
-        """
-    1. Open https://authorize.kobo.com/signin in a private/incognito window in your browser.
-    2. wait till the page loads (do not login!)
-    3. open the developer tools (use F12 in Firefox/Chrome, or right-click and choose "inspect")
-    4. select the console tab,
-    5. copy-paste the following code to the console there and then press Enter.
-
-    var newCaptchaDiv = document.createElement("div");
-    newCaptchaDiv.id = "new-hcaptcha-container";
-    var siteKey = document.getElementById('hcaptcha-container').getAttribute('data-sitekey');
-    document.body.replaceChildren(newCaptchaDiv);
-    grecaptcha.render(newCaptchaDiv.id, {
-        sitekey: siteKey,
-        callback: function(r) {console.log("Captcha response:");console.log(r);}
-    });
-    console.log('Click the checkbox to get the code');
-
-    A captcha should show up below the Sign-in form. Once you solve the captcha its response will be written
-    below the pasted code in the browser's console. Copy the response (the line below "Captcha response:")
-    and paste it here.  It will be very long!
-    """
-    )
-    if not captcha:
-        input('Press enter after copying the captcha code...')
-        captcha = pyperclip.paste().strip()
-        click.echo(f'Read captcha code from clipboard: {captcha}')
-    actions.Login(user, password, captcha)
+def add(ctx):
+    user = User()
+    actions.Login(user)
     Globals.Settings.UserList.users.append(user)
     Globals.Settings.Save()
     click.echo('Login Success. Try to list your books with `kobodl book list`')

--- a/kobodl/settings.py
+++ b/kobodl/settings.py
@@ -8,8 +8,9 @@ from dataclasses_json import dataclass_json
 @dataclass_json
 @dataclasses.dataclass
 class User:
-    Email: str
+    Email: str = ""
     DeviceId: str = ""
+    SerialNumber: str = ""
     AccessToken: str = ""
     RefreshToken: str = ""
     UserId: str = ""


### PR DESCRIPTION
This updates `user add` to use the same web-based activation approach used by Kobo e-readers, rather than trying to scrape the login page.

This has three main benefits:

 1. No need for the use to provide their password to kobodl. Instead, they log in using the Kobo website from their browser.
 2. Avoids the step of using devtools to extract a captcha code.
 3. (Hopefully) less prone to breakage, since it doesn't rely on scraping the login page.

This change was adapted from TnS-hun/kobo-book-downloader commit 04d8c42d97661bd580fbfe62d681c5be86edd1c4.

Fixes #121