### PR TITLE
Push docker image with latest/version tag on release, main on main commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/subdavis/kobodl:main
+          tags: ghcr.io/subdavis/kobodl:latest
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/subdavis/kobodl:latest
+          tags: ghcr.io/subdavis/kobodl:main
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,3 +63,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           asset_paths: '["./dist/kobodl*"]'
+  docker:
+    name: Publish Docker Container
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - 
+        name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          platforms: linux/amd64,linux/arm64
+          images: ghcr.io/subdavis/kobodl
+
+      - 
+        name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Generally better practice to use a tagged release not "latest" for consistency. I would use the sha, but i like the multi arch.
so release a tagged version on version creation.

Also use the shas for the new actions as thats the suggestion with the comprimised action a few weeks ago