### PR TITLE
feat: Add --only-new flag to skip previously downloaded books

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ kobodl book get \
 # Download ALL books with default options when only 1 user exists
 kobodl book get --get-all
 
+# Download only NEW books that weren't downloaded before
+kobodl book get --get-all --only-new
+
+
 # Download ALL books with advanced options
 kobodl book get \
   --user email@domain.com \

--- a/kobodl/commands/book.py
+++ b/kobodl/commands/book.py
@@ -39,6 +39,12 @@ def book():
 )
 @click.option('-a', '--get-all', is_flag=True)
 @click.option(
+    '-n', 
+    '--only-new', 
+    is_flag=True,
+    help='Only download books that have not been previously downloaded and tracked'
+)
+@click.option(
     '-f',
     '--format-str',
     type=click.STRING,
@@ -47,7 +53,7 @@ def book():
 )
 @click.argument('product-id', nargs=-1, type=click.STRING)
 @click.pass_obj
-def get(ctx, user, output_dir: Path, get_all: bool, format_str: str, product_id: List[str]):
+def get(ctx, user, output_dir: Path, get_all: bool, only_new: bool, format_str: str, product_id: List[str]):
     if len(Globals.Settings.UserList.users) == 0:
         click.echo('error: no users found.  Did you `kobodl user add`?', err=True)
         exit(1)
@@ -77,10 +83,10 @@ def get(ctx, user, output_dir: Path, get_all: bool, format_str: str, product_id:
 
     os.makedirs(output_dir, exist_ok=True)
     if get_all:
-        actions.GetBookOrBooks(usercls, output_dir, formatStr=format_str)
+        actions.GetBookOrBooks(usercls, output_dir, formatStr=format_str, onlyNew=only_new)
     else:
         for pid in product_id:
-            actions.GetBookOrBooks(usercls, output_dir, formatStr=format_str, productId=pid)
+            actions.GetBookOrBooks(usercls, output_dir, formatStr=format_str, productId=pid, onlyNew=only_new)
 
 
 @book.command(name='list', help='list books')

--- a/kobodl/settings.py
+++ b/kobodl/settings.py
@@ -1,6 +1,6 @@
 import dataclasses
 import os
-from typing import List, Union
+from typing import List, Union, Dict, Set
 
 from dataclasses_json import dataclass_json
 
@@ -47,10 +47,26 @@ class UserList:
         return None
 
 
+@dataclass_json
+@dataclasses.dataclass
+class DownloadedBooks:
+    books_by_user: Dict[str, Set[str]] = dataclasses.field(default_factory=dict)
+
+    def mark_downloaded(self, user_id: str, product_id: str) -> None:
+        if user_id not in self.books_by_user:
+            self.books_by_user[user_id] = set()
+        self.books_by_user[user_id].add(product_id)
+
+    def is_downloaded(self, user_id: str, product_id: str) -> bool:
+        user_downloads = self.books_by_user.get(user_id, set())
+        return product_id in user_downloads
+
+
 class Settings:
     def __init__(self, configpath=None):
         self.SettingsFilePath = configpath or Settings.__GetCacheFilePath()
         self.UserList = self.Load()
+        self.DownloadedBooks = self.LoadDownloadedBooks()
 
     def Load(self) -> UserList:
         if not os.path.isfile(self.SettingsFilePath):
@@ -59,9 +75,34 @@ class Settings:
             jsonText = f.read()
             return UserList.from_json(jsonText)
 
+    def LoadDownloadedBooks(self) -> DownloadedBooks:
+        downloads_path = self._get_downloads_file_path()
+        if not os.path.isfile(downloads_path):
+            return DownloadedBooks()
+        try:
+            with open(downloads_path, "r") as f:
+                jsonText = f.read()
+                return DownloadedBooks.from_json(jsonText)
+        except:
+            # If file is corrupted or has issues, start fresh
+            return DownloadedBooks()
+
     def Save(self) -> None:
         with open(self.SettingsFilePath, "w") as f:
             f.write(self.UserList.to_json(indent=4))
+
+    def SaveDownloadedBooks(self) -> None:
+        downloads_path = self._get_downloads_file_path()
+        os.makedirs(os.path.dirname(downloads_path), exist_ok=True)
+        with open(downloads_path, "w") as f:
+            f.write(self.DownloadedBooks.to_json(indent=4))
+
+    def _get_downloads_file_path(self) -> str:
+        # Store the downloads tracking file in the kobo_downloads directory
+        download_dir = os.path.join(os.getcwd(), "kobo_downloads")
+        # Make sure the directory exists
+        os.makedirs(download_dir, exist_ok=True)
+        return os.path.join(download_dir, "kobodl_downloads.json")
 
     @staticmethod
     def __GetCacheFilePath() -> str:


### PR DESCRIPTION
This change helps users avoid re-downloading books they already have by maintaining a record of downloaded books per user. The tracking file is stored in the kobo_downloads directory alongside the books.

I know it's already kindof there, but if I move the files out of the tracking folder, it gets re-downloaded - this new flag should prevent that.  Tracking is done automatically, without any flag - but I'm still not sure if this should be on by default or not. 