### PR TITLE
Same docker build on release.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,29 +4,43 @@ on:
   push:
     branches:
       - main
+  release:
+    types: 
+      - published
 
 jobs:
   publish:
     name: Publish Docker Container
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Build and push server
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: "ghcr.io/${{ github.repository_owner }}/kobodl"
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/subdavis/kobodl:latest
+          context: .
           push: true
+          platforms: "linux/amd64,linux/arm64"
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
* Tag with version tags when possible
* Tag with sha
* Always tag as latest

By using docker/metadata-action also get all the standard opencontainer labels so renovate/dependabot/updatecli/etc can generate pull requests with release notes