### PR TITLE
fix: don't interrupt batch download on HTTP errors

### DIFF
--- a/kobodl/actions.py
+++ b/kobodl/actions.py
@@ -267,18 +267,18 @@ def GetBookOrBooks(
         try:
             click.echo(f'Downloading {currentProductId} to {outputFilePath}', err=True)
             kobo.Download(bookMetadata, book_type == BookType.AUDIOBOOK, outputFilePath)
-        except KoboException as e:
+        except Exception as e:
             if productId:
                 raise e
-            else:
-                click.echo(
-                    (
-                        f'Skipping failed download for {currentProductId}: {str(e)}'
-                        '\n  -- Try downloading it as a single book to get the complete exception details'
-                        ' and open an issue on the project GitHub page: https://github.com/subdavis/kobo-book-downloader/issues'
-                    ),
-                    err=True,
-                )
+
+            click.echo(
+                (
+                    f'Skipping failed download for {currentProductId}: {str(e)}'
+                    '\n  -- Try downloading it as a single book to get the complete exception details'
+                    ' and open an issue on the project GitHub page: https://github.com/subdavis/kobo-book-downloader/issues'
+                ),
+                err=True,
+            )
 
         if productId:
             # TODO: support audiobook downloads from web


### PR DESCRIPTION
This should fix https://github.com/subdavis/kobo-book-downloader/issues/152

`response.raise_for_status()` calls  in `kobo.Download()` raise `HTTPError`, but since these don't have to be handled in a distinct way to `KoboException`, a simple `except Exception as e:` ought to work just fine here.