### PR TITLE
Fix audiobook downloads failing with S3 SignatureDoesNotMatch

### DIFF
--- a/kobodl/kobo.py
+++ b/kobodl/kobo.py
@@ -307,8 +307,10 @@ class Kobo:
 
     def __DownloadToFile(self, url, outputPath: str) -> None:
         headers = {}
-        if 'amazonaws.com' in url:
-            headers["x-amz-request-payer"] = "requester"
+        # Kobo serves content via storedownloads.kobo.com URLs that redirect to
+        # requester-pays S3 presigned URLs (which sign host;x-amz-request-payer).
+        # Always send the header so it survives the redirect; non-S3 hosts ignore it.
+        headers["x-amz-request-payer"] = "requester"
         if 'kobo.com' in url and 'amazonaws.com' not in url:
             headers.update(self.__GetHeaderWithAccessToken())
         response = self.Session.get(url, headers=headers, stream=True)
@@ -319,8 +321,9 @@ class Kobo:
 
     def __DownloadAudiobook(self, url, outputPath: str) -> None:
         headers = {}
-        if 'amazonaws.com' in url:
-            headers["x-amz-request-payer"] = "requester"
+        # See __DownloadToFile: send x-amz-request-payer unconditionally so it
+        # survives the storedownloads.kobo.com -> S3 redirect.
+        headers["x-amz-request-payer"] = "requester"
         if 'kobo.com' in url and 'amazonaws.com' not in url:
             headers.update(self.__GetHeaderWithAccessToken())
         response = self.Session.get(url, headers=headers)
@@ -334,8 +337,9 @@ class Kobo:
             fileNum = int(item['Id']) + 1
             fileUrl = item['Url']
             fileHeaders = {}
-            if 'amazonaws.com' in fileUrl:
-                fileHeaders["x-amz-request-payer"] = "requester"
+            # Spine entries are storedownloads.kobo.com URLs that redirect to
+            # requester-pays S3; send the header unconditionally so it survives.
+            fileHeaders["x-amz-request-payer"] = "requester"
             if 'kobo.com' in fileUrl and 'amazonaws.com' not in fileUrl:
                 fileHeaders.update(self.__GetHeaderWithAccessToken())
             response = self.Session.get(fileUrl, headers=fileHeaders, stream=True)


### PR DESCRIPTION
> [!NOTE]
> I was unable to download an audio book, but Claude code generated this fix which worked on my machine. Feel free to use if you want.

Audiobook downloads (`kobodl book get`) currently write ~2.6 KB XML error blobs in place of each `N.mp3` chapter.

## Root cause

Kobo now serves audiobook spine content via `storedownloads.kobo.com/download?downloadToken=…` URLs that **302-redirect** to a requester-pays S3 presigned URL on `bsa-dist-kobo.s3-accelerate.amazonaws.com`. That presigned URL signs `host;x-amz-request-payer`, so the client must send `x-amz-request-payer: requester` or S3 rejects it.

The download paths decide whether to attach that header by string-matching `amazonaws.com in url`. Because the spine URL host is now `kobo.com`, the header was never attached. `requests` follows the redirect to S3 without it, and S3 returns:

```
403 <Code>SignatureDoesNotMatch</Code>
```

…with `<CanonicalRequest>` showing `x-amz-request-payer:` empty. That XML body gets written to disk as the chapter file.

## Fix

Send `x-amz-request-payer: requester` unconditionally in the three download paths (`__DownloadToFile`, `__DownloadAudiobook`, and its per-spine loop). `requests` carries the header across the `storedownloads.kobo.com → S3` redirect, and non-S3 hosts ignore an unknown request header, so this is safe for ebooks too.

## Testing

Reproduced against a purchased audiobook:

- Direct S3 presigned URL **without** the header → `403`, 2594-byte `SignatureDoesNotMatch` (matches the bad on-disk blobs).
- Same URL **with** `x-amz-request-payer: requester` → `200`, real `ID3`/MPEG audio.
- `kobodl book get <id>` from this branch → all 11 chapters valid `MPEG ADTS layer III` audio, zero error blobs.