### PR TITLE
Add option to exclude previews from `--get-all` downloads

### DIFF
--- a/kobodl/actions.py
+++ b/kobodl/actions.py
@@ -212,7 +212,7 @@ def GetBookOrBooks(
     outputPath: str,
     formatStr: str = r'{Author} - {Title} {ShortRevisionId}',
     productId: str = '',
-    excludePreviews: bool = True,
+    includePreviews: bool = True,
 ) -> Union[None, str]:
     """
     download 1 or all books to file
@@ -233,9 +233,10 @@ def GetBookOrBooks(
         if newEntitlement is None:
             continue
 
-        if excludePreviews and newEntitlement.get('BookEntitlement') is not None:
+        if not includePreviews and newEntitlement.get('BookEntitlement') is not None:
             access =  newEntitlement.get('BookEntitlement').get('Accessibility')
             if access != 'Full':
+                click.echo(f'Skipping {access} access book')
                 continue
 
         bookMetadata, book_type = __GetBookMetadata(newEntitlement)

--- a/kobodl/actions.py
+++ b/kobodl/actions.py
@@ -212,6 +212,7 @@ def GetBookOrBooks(
     outputPath: str,
     formatStr: str = r'{Author} - {Title} {ShortRevisionId}',
     productId: str = '',
+    excludePreviews: bool = True,
 ) -> Union[None, str]:
     """
     download 1 or all books to file
@@ -231,6 +232,11 @@ def GetBookOrBooks(
         newEntitlement = entitlement.get('NewEntitlement')
         if newEntitlement is None:
             continue
+
+        if excludePreviews and newEntitlement.get('BookEntitlement') is not None:
+            access =  newEntitlement.get('BookEntitlement').get('Accessibility')
+            if access != 'Full':
+                continue
 
         bookMetadata, book_type = __GetBookMetadata(newEntitlement)
         if book_type is None:

--- a/kobodl/commands/book.py
+++ b/kobodl/commands/book.py
@@ -38,6 +38,7 @@ def book():
     help='default: kobo_downloads',
 )
 @click.option('-a', '--get-all', is_flag=True)
+@click.option('-p', '--include-previews', is_flag=True)
 @click.option(
     '-f',
     '--format-str',
@@ -52,7 +53,7 @@ def book():
 )
 @click.argument('product-id', nargs=-1, type=click.STRING)
 @click.pass_obj
-def get(ctx, user, output_dir: Path, get_all: bool, format_str: str, product_id: List[str]):
+def get(ctx, user, output_dir: Path, get_all: bool, include_previews: bool, format_str: str, product_id: List[str]):
     if len(Globals.Settings.UserList.users) == 0:
         click.echo('error: no users found.  Did you `kobodl user add`?', err=True)
         exit(1)
@@ -82,7 +83,7 @@ def get(ctx, user, output_dir: Path, get_all: bool, format_str: str, product_id:
 
     os.makedirs(output_dir, exist_ok=True)
     if get_all:
-        actions.GetBookOrBooks(usercls, output_dir, formatStr=format_str)
+        actions.GetBookOrBooks(usercls, output_dir, formatStr=format_str, includePreviews=include_previews)
     else:
         for pid in product_id:
             actions.GetBookOrBooks(usercls, output_dir, formatStr=format_str, productId=pid)


### PR DESCRIPTION
I have a number of books on pre-order and previews saved that I don't want to download when I download my entire library. I've put in a flag which excludes anything that isn't "Full" access.

The values I've seen for `NewEntitlement.BookEntitlement.Accessibility` are `"Full"`, `"Preorder"`, and `"Preview"`.

