### PR TITLE
Bundle Jinja templates in pyinstaller builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,26 @@ jobs:
           pip install tox;
       -
         run: tox -e buildcli -- --name kobodl-${{ matrix.name }}
+      -
+        name: Smoke test the web server
+        shell: bash
+        run: |
+          ./dist/kobodl-${{ matrix.name }}* serve --port 8451 > serve.log 2>&1 &
+          server_pid=$!
+          status=1
+          for _ in $(seq 30); do
+            if curl -fsS http://127.0.0.1:8451/user > /dev/null; then
+              status=0
+              break
+            fi
+            sleep 1
+          done
+          kill $server_pid || true
+          cat serve.log
+          if [ $status -ne 0 ]; then
+            echo "::error::the bundled web server could not render /user"
+          fi
+          exit $status
       - 
         name: Upload Release Asset
         uses: alexellis/upload-assets@0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -22,8 +22,6 @@ commands =
 [testenv:buildcli]
 deps =
     pyinstaller
-    # a temporary pin for Jinja/Sphinx
-    # because MarkupSafe 2.1.0 is a breaking change
-    MarkupSafe==2.0.1
 commands =
-    pyinstaller --onefile kobodl/__main__.py {posargs}
+    # --collect-data bundles kobodl/templates, without which `kobodl serve` cannot render any page
+    pyinstaller --onefile --collect-data kobodl kobodl/__main__.py {posargs}


### PR DESCRIPTION
Fixes #51

## Problem

`kobodl serve` is broken in the pyinstaller release binaries. The build ran `pyinstaller --onefile kobodl/__main__.py` without declaring any data files, and pyinstaller only bundles Python modules it can trace through imports — so `kobodl/templates/` never made it into the bundle.

The binary starts up and binds a port normally, so the failure is invisible until you actually load a page, at which point every route dies with:

```
jinja2.exceptions.TemplateNotFound: users.j2
```

Flask's `root_path` resolution is not at fault here and needs no change: pyinstaller sets `__file__` to a path under `sys._MEIPASS`, so Flask already looks in the right place. The templates simply weren't there. This was purely a packaging omission, which is why pip and docker installs are unaffected.

## Fix

Add `--collect-data kobodl` to the build, which places all seven templates at `kobodl/templates` inside the bundle, exactly where Flask looks.

I chose this over an explicit `--add-data kobodl/templates:kobodl/templates` for two reasons:

- It sidesteps the source/destination separator that differs between Windows (`;`) and POSIX (`:`).
- It picks up any template or static file added in the future, instead of requiring a hand-maintained list — the same omission is otherwise easy to repeat.

## Preventing the regression

This class of bug is invisible in CI because the build succeeds and only rendering fails, so it took a user report to surface it. This PR adds a smoke test that starts the freshly built binary, polls `GET /user` for up to 30 seconds, and fails the job if it never returns 200. It runs before the asset upload step, so a bundle that cannot render can no longer be attached to a release.

`/user` is a good canary: it pulls in four templates via `{% include %}` and needs no Kobo credentials or network access.

Two deliberate details in that step:

- The server's output goes to `serve.log` rather than inheriting the step's stdout, since a background process holding that pipe open can hang Windows runners. The log is printed afterward so failures are diagnosable.
- The binary is referenced via a glob so the same script covers the `.exe` suffix on Windows.

## Drive-by cleanup

Removed the `MarkupSafe==2.0.1` pin from the same tox environment. It was labeled temporary in 2022 and is now a no-op: the CI log from the 0.14.0 release shows the environment resolving to `MarkupSafe==3.0.3` anyway, because installing the package's own dependencies overrides it. There is also no wheel of 2.0.1 for Python 3.11, so it was only ever a slow source build or silently ignored.

## Test plan

Verified locally on macOS through `tox -e buildcli -- --name kobodl-macos`, the exact command CI runs:

- [x] Reproduced the bug on a pre-fix build — `GET /user` returns 500 with `TemplateNotFound: users.j2`
- [x] Post-fix build returns 200 and renders the complete page, including header and footer `{% include %}` content
- [x] Confirmed the tox comment does not break ini parsing; the resolved command is `pyinstaller --onefile --collect-data kobodl kobodl/__main__.py --name kobodl-macos`
- [x] Smoke test script exits 0 against the fixed binary
- [x] Smoke test script exits 1 with the error annotation against the old broken binary

One caveat: I could only build and run on macOS, so the Windows and Linux binaries aren't directly exercised here. The new smoke test will cover all three platforms on the next release.

Made with [Cursor](https://cursor.com)